### PR TITLE
Fix erppeek version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='http://github.com/totaler/erppeek_wst',
     author='Joan M. Grande',
     author_email='totaler@gmail.com',
-    install_requires=['erppeek'],
+    install_requires=['erppeek<=1.4.5'],
     py_modules=['erppeek_wst'],
     platforms='any',
     keywords="openerp xml-rpc xmlrpc",


### PR DESCRIPTION
To avoid:

```
Traceback (most recent call last):
  File "/home/erp/src/erp/server/bin/osv/osv.py", line 58, in wrapper
    return f(self, dbname, *args, **kwargs)
  File "/home/erp/src/erp/server/bin/osv/osv.py", line 132, in execute
    netsvc.SERVICES[service_name].close()
  File "/home/erp/lib/python2.7/site-packages/erppeek_wst.py", line 51, in close
    self._close(self.transaction_id)
TypeError: close() takes exactly 1 argument (5 given)
```
